### PR TITLE
remove consumer.close()

### DIFF
--- a/workshop/2-consume.ipynb
+++ b/workshop/2-consume.ipynb
@@ -102,17 +102,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Finally close the consumer to discontinue\n",
-    "\n",
-    "consumer.close()   "
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/workshop/2-consume.ipynb
+++ b/workshop/2-consume.ipynb
@@ -88,17 +88,17 @@
     "finished = False\n",
     "local_count = 0\n",
     "\n",
-    "    consumer.subscribe([\"pizzas\"])\n",
-    "    with console.status(\"Please run the last Python block in 1-produce.ipynb\"):\n",
-    "        while not finished:\n",
-    "            if (msg:=consumer.poll(timeout=1.0)) is None:\n",
-    "               continue\n",
-    "            elif msg.error():\n",
-    "                    raise KafkaException(msg.error())\n",
-    "            else:\n",
-    "                console.print(f\"{msg.offset()}: {msg.key()}:{msg.value()}\\n\\n\")\n",
-    "                local_count += 1\n",
-    "                finished = local_count == 2\n"
+    "consumer.subscribe([\"pizzas\"])\n",
+    "with console.status(\"Please run the last Python block in 1-produce.ipynb\"):\n",
+    "    while not finished:\n",
+    "        if (msg:=consumer.poll(timeout=1.0)) is None:\n",
+    "            continue\n",
+    "        elif msg.error():\n",
+    "                raise KafkaException(msg.error())\n",
+    "        else:\n",
+    "            console.print(f\"{msg.offset()}: {msg.key()}:{msg.value()}\\n\\n\")\n",
+    "            local_count += 1\n",
+    "            finished = local_count == 2\n"
    ]
   },
   {

--- a/workshop/2-consume.ipynb
+++ b/workshop/2-consume.ipynb
@@ -88,7 +88,6 @@
     "finished = False\n",
     "local_count = 0\n",
     "\n",
-    "try:\n",
     "    consumer.subscribe([\"pizzas\"])\n",
     "    with console.status(\"Please run the last Python block in 1-produce.ipynb\"):\n",
     "        while not finished:\n",
@@ -99,10 +98,18 @@
     "            else:\n",
     "                console.print(f\"{msg.offset()}: {msg.key()}:{msg.value()}\\n\\n\")\n",
     "                local_count += 1\n",
-    "                finished = local_count == 2\n",
-    "finally:\n",
-    "    # Close down consumer to commit final offsets.\n",
-    "    consumer.close()   "
+    "                finished = local_count == 2\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Finally close the consumer to discontinue\n",
+    "\n",
+    "consumer.close()   "
    ]
   },
   {

--- a/workshop/4-consume-partition-0.ipynb
+++ b/workshop/4-consume-partition-0.ipynb
@@ -61,7 +61,6 @@
     "\n",
     "load_dotenv()\n",
     "\n",
-    "\n",
     "def json_deserializer(msg, s_obj):\n",
     "    return json.loads(msg.decode('ascii'))\n",
     "\n",


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

this removes the consumer.close into its own block so that you can rerun the consumer block as often as you wish

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

